### PR TITLE
Remove dependency on Prov Store for conversion to turtle

### DIFF
--- a/TestSPMResultDataModel.py
+++ b/TestSPMResultDataModel.py
@@ -12,9 +12,6 @@ python test/TestSPMResultDataModel.py
 '''
 import unittest
 import os
-from subprocess import call
-import re
-import rdflib
 from rdflib.graph import Graph
 import logging
 logging.basicConfig(level=logging.DEBUG)
@@ -97,7 +94,7 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
     def test03_ex1_auditory_singlesub_full_graph(self):
         #  Turtle file of ground truth (manually computed) RDF
         ground_truth_provn = os.path.join(self.ground_truth_dir, 'example001_spm_results.provn');
-        ground_truth_ttl = get_turtle(ground_truth_provn)
+        ground_truth_ttl = ground_truth_provn.replace(".provn", ".ttl")
 
         # print "\n\nwith: "+ground_truth_ttl
 


### PR DESCRIPTION
Hi @gllmflndn.

If you accept this pull request, the tests will be able to run without calling the Prov Store APIs. The turtle version of the ground truth are now stored in the `nidm` repository (incf-nidash/nidm#209) and the dependency on the Prov Store APIs is therefore not needed anymore.
